### PR TITLE
Remove '#theme' hook

### DIFF
--- a/src/Plugin/Field/FieldFormatter/JQueryExpander.php
+++ b/src/Plugin/Field/FieldFormatter/JQueryExpander.php
@@ -153,7 +153,6 @@ class JQueryExpander extends FormatterBase {
     foreach ($items as $delta => $item) {
       // Render each element as markup.
       $element[$delta] = [
-        '#theme' => 'jquery_expander',
         '#type' => 'markup',
         '#markup' => $item->value,
         '#prefix' => '<div class="field-expander field-expander-' . $delta . '">',


### PR DESCRIPTION
When using `#type` there's no need to define `#theme`.